### PR TITLE
Update date format of Get-PCUsage sample command

### DIFF
--- a/CmdletHelp/Get-PCUsage.md
+++ b/CmdletHelp/Get-PCUsage.md
@@ -12,5 +12,5 @@
 
 **Gets the utilization records of a customer's Azure subscription for a specified time period**
 
-    Get-PCUsage -subscriptionid $subscription.id -start_time "01-12-1999 00:00:00" -end_time "31-12-1999 00:00:00" -granularity {daily | hourly}-show_details  <bool> -size <int>
+    Get-PCUsage -subscriptionid $subscription.id -start_time "01-12-1999 00:00:00" -end_time "12-31-1999 00:00:00" -granularity {daily | hourly}-show_details  <bool> -size <int>
 


### PR DESCRIPTION
Previous comand sample contains the datetime "31-12-1999 00:00:00". This month number is 31. If we use this sample, we should get error about datetime format. So I modify the sample. We should also modify the following 2 error messages.

"Start time is not in a valid format. Use '31-12-1999 00:00:00' format"
"End time is not in a valid format. Use '31-12-1999 00:00:00' format"