### PR TITLE
Fixed bug with not escaped client secret

### DIFF
--- a/CmdletHelp/Add-PCAuthentication.md
+++ b/CmdletHelp/Add-PCAuthentication.md
@@ -13,6 +13,6 @@
     $clientSecret = '<key code secret>'
 	$clientSecretSecure = $clientSecret | ConvertTo-SecureString -AsPlainText -Force
 
-	Add-PCAuthentication -cspappID '<native app id GUID>' -cspDomain '<csp partner domain>' -cspClientSecret $clientSecretSecure
+	Add-PCAuthentication -cspappID '<web app id GUID>' -cspDomain '<csp partner domain>' -cspClientSecret $clientSecretSecure
 
-
+You can obtain the Web App ID and the Client Secret from either Partner Center UI or Azure Active Directory

--- a/PartnerCenterModule/PartnerCenterAuthentication.psm1
+++ b/PartnerCenterModule/PartnerCenterAuthentication.psm1
@@ -42,6 +42,8 @@ function Get-GraphAADTokenByApp
     $body = $body + "resource=$resource&"
     $body = $body + "client_id=$clientid&"
     $tmp_clientsecret = _unsecureString -string $clientsecret
+    # we need to escape the secret because it may contain special chars
+    $tmp_clientsecret = [uri]::EscapeDataString($tmp_clientsecret)
     $body = $body + "client_secret=$tmp_clientsecret"
 
     $response = Invoke-RestMethod -Uri $url -ContentType "application/x-www-form-urlencoded" -Body $body -method "POST" #-Debug -Verbose -Headers $headers 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ or
     $clientSecret = '<key code secret>'
 	$clientSecretSecure = $clientSecret | ConvertTo-SecureString -AsPlainText -Force
 
-	Add-PCAuthentication -cspappID '<native app id GUID>' -cspDomain '<csp partner domain>' -cspClientSecret $clientSecretSecure
+	Add-PCAuthentication -cspappID '<web app id GUID>' -cspDomain '<csp partner domain>' -cspClientSecret $clientSecretSecure
+
+You can obtain the Web App ID and the Client Secret from either Partner Center UI or Azure Active Directory
 
 ### Ready ###
 After this first steps you are ready to start using bellow cmdlet scenarios. (ex: create customers, create subscriptions, etc)


### PR DESCRIPTION
This caused issue with invalid credentials when trying to authenticate with app ID and app Key