### PR TITLE
Removing status as it breaks New-PCOrder cmdlet

### DIFF
--- a/PartnerCenterModule/PartnerCenterModule.psm1
+++ b/PartnerCenterModule/PartnerCenterModule.psm1
@@ -242,7 +242,7 @@ class Order
     [Array] $LineItems
 
     #Optional fields
-    [string] $Status = 'none'
+    #[string] $Status = 'none'
     [string] $CreationDate
     [string] $BillingCycleType
     [Attributes] $Attributes


### PR DESCRIPTION
As per issue https://github.com/Microsoft/PartnerCenterPowerShellModule/issues/50

We cannot use New-PCOrder function as it throws the following error:
Invoke-RestMethod : {"code":0,"description":"The provided value 'none' is not a valid OrderStatus.","data":[],"source":"PartnerFD"}
At C:\Program Files\WindowsPowerShell\Modules\PartnerCenterModule\0.9.0.16\PartnerCenterOrder.psm1:96 char:17
+ ... $response = Invoke-RestMethod -Uri $url -Headers $headers -ContentTyp ...

Looking at the REST API Documentation - https://docs.microsoft.com/en-us/partner-center/develop/orders#order

Order does not accept status value so by removing it from the POST and PATCH request, New-PCOrder starts to work again.

Order class example prior:

$order


Id                  :
ReferenceCustomerId : xxxxx-xxxx-xxxx-xxxx-xxxxxxx
LineItems           : {Microsoft Azure}
Status              : none
CreationDate        :
BillingCycleType    :
Attributes          : Attributes

Order class example after:

$order


Id                  :
ReferenceCustomerId :  xxxxxx-xxxx-xxxx-xxxx-xxxxxxx
LineItems           : {Microsoft Azure}
CreationDate        :
BillingCycleType    :
Attributes          : Attributes

As you can see status is gone and now I can create new order:


PS C:\Users\sucblack> Invoke-RestMethod -Uri $url -Headers $headers -ContentType "application/json" -Body $body -Method $method #-Debug -Verbose
﻿{"id":"xxxxxx-xxxx-xxxx-xxxx-xxxxxxxx","referenceCustomerId":"xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx","billingCycle":"monthly","lineItems":[{"lineItemNumber":0,"offerId":"MS-AZR-0145P","subscriptionId":"xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx","friendlyName":"Microsoft Azure","quantity":1,"links":{"subscription":{"uri":"/customers/xxxxxxxx-xxxx-xxxxxxxx-xxxxxxxx/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxx","method":"GET","headers":[]}}}],"creationDate":"2018-03-06T04:38:48.17-08:00","status":"completed","links":{"self":{"uri":"/customers/xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/orders/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx","method":"GET","headers":[]}},"attributes":{"etag":"xxxxxxxMjgzLTkyZDxxxxxxxxxxxWI2ODlmODk1ZDhmNCIsInZlcnNpb24iOjF9","objectType":"Order"}}


