### PR TITLE
fixed customer creation issue

### DIFF
--- a/CmdletHelp/New-PCCustomer.md
+++ b/CmdletHelp/New-PCCustomer.md
@@ -2,13 +2,12 @@
 
 ## New-PCCustomer ##
 
-**Create new customer**
+Create new customer
 
-    $newDefaultAddress = New-PCCustomerDefaultAddress -Country '<country code>' -Region '<region>' -City '<city>' -State '<state>' -AddressLine1 '<address1>' -PostalCode <postal code> -FirstName '<first name>' -LastName '<last name>' -PhoneNumber <phone number>
+    $newDefaultAddress = New-PCCustomerDefaultAddress -Country '<country code>' -Region '<region>' -City '<city>' -State '<state>' -AddressLine1 '<address1>' -PostalCode '<postal code>' -FirstName '<first name>' -LastName '<last name>' -PhoneNumber '<phone number>'
 
-    $newBillingProfile = New-PCCustomerBillingProfile -Email '<email>' -Culture '<ex: en.us>' -Language '<ex: en>' -CompanyName '<company name>' -DefaultAddress $newDefaultAddress
+    $newBillingProfile = New-PCCustomerBillingProfile -FirstName '<first name>' -LastName '<last name>' -Email '<email>' -Culture '<ex: en.us>' -Language '<ex: en>' -CompanyName '<company name>' -DefaultAddress $newDefaultAddress
 
     $newCompanyProfile = New-PCCustomerCompanyProfile -Domain '<company name>.onmicrosoft.com'
 
     $newCustomer = New-PCCustomer -BillingProfile $newBillingProfile -CompanyProfile $newCompanyProfile
-

--- a/PartnerCenterModule/PartnerCenterCustomer.psm1
+++ b/PartnerCenterModule/PartnerCenterCustomer.psm1
@@ -178,9 +178,9 @@ function New-PCCustomer
     
     switch ($PsCmdlet.ParameterSetName)
     {
-        'AllDetails' { $customer = [Customer]::new($Email,$Culture,$Language,$CompanyName,$Country,$Region,$City,$State,$AddressLine1, `
-                                                   $PostalCode, $FirstName, $LastName,  $PhoneNumber,$Domain) }
-        'ByProfiles' { $customer = [Customer]::new($BillingProfile,$CompanyProfile)}
+        'AllDetails' { $customer = [Customer]::new($Email, $Culture, $Language, $CompanyName, $Country, $Region, $City, $State, $AddressLine1, `
+                                                   $PostalCode, $FirstName, $LastName, $PhoneNumber, $Domain) }
+        'ByProfiles' { $customer = [Customer]::new($BillingProfile, $CompanyProfile)}
     }
         
     $body = $customer | ConvertTo-Json -Depth 100

--- a/PartnerCenterModule/PartnerCenterModule.psm1
+++ b/PartnerCenterModule/PartnerCenterModule.psm1
@@ -69,7 +69,6 @@ class DefaultAddress
                 [string] $PostalCode, [string] $FirstName, [string] $LastName, [string] $PhoneNumber)
     {
         $this.Country = $Country
-        $this.Region = $Region
         $this.City = $City
         $this.State = $State
         $this.AddressLine1 = $AddressLine1
@@ -77,17 +76,24 @@ class DefaultAddress
         $this.FirstName = $FirstName
         $this.LastName = $LastName
         $this.PhoneNumber = $PhoneNumber
+
+        if(-not [string]::IsNullOrEmpty($Region)) {
+            $this.Region = $Region            
+        }
     }
 
     DefaultAddress ([string] $Country, [string] $Region, [string] $City, [string] $State, [string] $AddressLine1, `
                 [string] $PostalCode)
     {
         $this.Country = $Country
-        $this.Region = $Region
         $this.City = $City
         $this.State = $State
         $this.AddressLine1 = $AddressLine1
         $this.PostalCode = $PostalCode
+
+        if(-not [string]::IsNullOrEmpty($Region)) {
+            $this.Region = $Region            
+        }
     }
 }
 
@@ -96,6 +102,8 @@ class BillingProfile
     #read only
     [string] $Id
 
+    [string] $FirstName
+    [string] $LastName
     [string] $Email
     [string] $Culture
     [string] $Language
@@ -109,6 +117,8 @@ class BillingProfile
         $defaultAddresstmp = [DefaultAddress]::new($Country, $Region, $City,$State,$AddressLine1,$PostalCode,$FirstName,$LastName,$PhoneNumber)
         $att_tmp = [Attributes]::new('BillingProfile')
 
+        $this.FirstName = $FirstName
+        $this.LastName = $LastName
         $this.DefaultAddress = $defaultAddresstmp
         $this.Email = $Email
         $this.Culture = $Culture
@@ -117,10 +127,12 @@ class BillingProfile
         $this.Attributes = $att_tmp
     }
 
-    BillingProfile ([string] $Email,[string]$Culture,[string]$Language,[string]$CompanyName,[DefaultAddress] $DefaultAddress)
+    BillingProfile ([string]$FirstName, [string]$LastName, [string] $Email,[string]$Culture,[string]$Language,[string]$CompanyName,[DefaultAddress] $DefaultAddress)
     {
         $att_tmp = [Attributes]::new('BillingProfile')
 
+        $this.FirstName = $FirstName
+        $this.LastName = $LastName
         $this.Email = $Email
         $this.Culture = $Culture
         $this.Language = $Language
@@ -136,7 +148,7 @@ class Customer
     #read only
     [string] $Id
     [string] $CommerceId
-    [string] $RelationshipToPartner = 'none'
+    [string] $RelationshipToPartner = 'unknown'
     [string] $UserCredentials
 
     #mandatoryFields
@@ -156,7 +168,7 @@ class Customer
         $defaultaddress_tmp = [DefaultAddress]::new($Country,$Region,$City,$State,$AddressLine1, `
                                                         $PostalCode,$FirstName,$LastName,$PhoneNumber)
 
-        $billingprofile_tmp = [BillingProfile]::new($Email,$Culture,$Language,$CompanyName,$defaultaddress_tmp)
+        $billingprofile_tmp = [BillingProfile]::new($FirstName, $LastName, $Email,$Culture,$Language,$CompanyName,$defaultaddress_tmp)
 
         $companyprofile_tmp = [CompanyProfile]::new($Domain)
         $att_tmp = [Attributes]::new('Customer')

--- a/PartnerCenterModule/PartnerCenterProfiles.psm1
+++ b/PartnerCenterModule/PartnerCenterProfiles.psm1
@@ -357,18 +357,18 @@ function New-PCCustomerBillingProfile
 {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $true)][string]$FirstName,
+        [Parameter(Mandatory = $true)][string]$LastName,
         [Parameter(Mandatory = $true)][string]$Email,
         [Parameter(Mandatory = $true)][string]$Culture,
         [Parameter(Mandatory = $true)][string]$Language,
         [Parameter(Mandatory = $true)][string]$CompanyName,
         [Parameter(ParameterSetName='AllDetails',Mandatory = $true)][string]$Country, 
-        [Parameter(ParameterSetName='AllDetails',Mandatory = $false)][string]$Region = "",
+        [Parameter(ParameterSetName='AllDetails',Mandatory = $false)][string]$Region = $null,
         [Parameter(ParameterSetName='AllDetails',Mandatory = $true)][string]$City, 
         [Parameter(ParameterSetName='AllDetails',Mandatory = $true)][string]$State, 
         [Parameter(ParameterSetName='AllDetails',Mandatory = $true)][string]$AddressLine1,
         [Parameter(ParameterSetName='AllDetails',Mandatory = $true)][string]$PostalCode, 
-        [Parameter(ParameterSetName='AllDetails',Mandatory = $true)][string]$FirstName,
-        [Parameter(ParameterSetName='AllDetails',Mandatory = $true)][string]$LastName, 
         [Parameter(ParameterSetName='AllDetails',Mandatory = $true)][string]$PhoneNumber,
         [Parameter(ParameterSetName='DefaultAddress',Mandatory = $true)][DefaultAddress]$DefaultAddress
     )
@@ -377,7 +377,7 @@ function New-PCCustomerBillingProfile
     {
         'AllDetails'    { $billingProfile = [BillingProfile]::new($Email,$Culture,$Language,$CompanyName,$Country,$Region,$City,$State,$AddressLine1, `
                                                    $PostalCode, $FirstName, $LastName,  $PhoneNumber) }
-        'DefaultAddress'{ $billingProfile = [BillingProfile]::new($Email,$Culture,$Language,$CompanyName,$DefaultAddress)}
+        'DefaultAddress'{ $billingProfile = [BillingProfile]::new($FirstName, $LastName, $Email,$Culture,$Language,$CompanyName,$DefaultAddress)}
     }
 
     return $billingProfile
@@ -388,7 +388,7 @@ function New-PCCustomerDefaultAddress
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)][string]$Country, 
-        [Parameter(Mandatory = $false)][string]$Region = "", 
+        [Parameter(Mandatory = $false)][string]$Region = $null, 
         [Parameter(Mandatory = $true)][string]$City, 
         [Parameter(Mandatory = $true)][string]$State, 
         [Parameter(Mandatory = $true)][string]$AddressLine1,
@@ -422,8 +422,8 @@ function New-PCAddress
         [Parameter(Mandatory = $true)][string]$City, 
         [Parameter(Mandatory = $true)][string]$State, 
         [Parameter(Mandatory = $true)][string]$PostalCode, 
-        [Parameter(Mandatory = $true)][string]$country,
-        [Parameter(Mandatory = $false)][string]$region = ""
+        [Parameter(Mandatory = $true)][string]$Country,
+        [Parameter(Mandatory = $false)][string]$Region = $null
     )
     
     $Address = [DefaultAddress]::new($Country, $Region, $City,$State,$AddressLine1,$PostalCode)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # Partner Center PowerShell Module (preview) #
 
 ## What is ##
+
 Partner Center Powershell Module is the powershell implementation of the Partner Center API available scenarios. You can manage your customers, offers, subscriptions, usage, etc. Objective is to keep this module as close as possible to the Partner Center SDK functionalities. 
 
 ## How to install ##
+
 This module is published via [PowerShell Gallery](https://www.powershellgallery.com/) so it can be installed using Install-Module.
 
     Install-Module -Name PartnerCenterModule
 
 ### Import Classes ###
+
 To Import Classes so that you can use fuctions like New-PCOrder.
 
     using module PartnerCenterModule
 
 ## How to use ##
+
 ### Step 1 ###
+
    Make sure your [App Management is already configured](https://msdn.microsoft.com/library/partnercenter/mt709136.aspx) to enable access to Partner Center API.
 
 ### Step 2 ###
+
 Just like with AzureRM powershell module, the first step to start using it is to provide authentication. In Partner Center PowerShell Module you use [Add-PCAuthentication](./CmdletHelp/Add-PCAuthentication.md) cmdlet. This will set your CSP account authentication context.
 
 **Set user authentication**
@@ -37,6 +43,7 @@ or
 You can obtain the Web App ID and the Client Secret from either Partner Center UI or Azure Active Directory
 
 ### Ready ###
+
 After this first steps you are ready to start using bellow cmdlet scenarios. (ex: create customers, create subscriptions, etc)
 
 ## Partner Center API scenario -> powershell module matrix ##


### PR DESCRIPTION
When attempting to create a customer a generic error was thrown. To address this error the following changes were made 

1. Added the appropriate logic to ensure that the region property of the default address object is null when it is not specified
 2. Added first and last name to the billing profile to match the PC SDK
