### PR TITLE
Fixed usage eternal loop when more than 1000 elements

### DIFF
--- a/PartnerCenterModule/PartnerCenterUsage.psm1
+++ b/PartnerCenterModule/PartnerCenterUsage.psm1
@@ -65,7 +65,8 @@ function Get-PCUsage {
             do {
             
                 $r = Get-PCUsage_implementation -SaToken $SaToken -ContinuationLink $retObject.links
-                $returnItems += $r.Items
+				$retObject = $r
+				$returnItems += $r.Items
 
             }
             until(!($r.links.PsObject.Properties.Name -match 'next'))


### PR DESCRIPTION
# Description

Start getting usage with a tenant with a subscription with more than 1000 items, it will loop forever because the refered object is never updated

## Related issue

Fixes #79